### PR TITLE
Update license type

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "cropper"
   ],
   "author": "twhitbeck",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/twhitbeck/angular-cropper/issues"
   },


### PR DESCRIPTION
The [LICENSE file](https://github.com/twhitbeck/angular-cropper/blob/master/LICENSE) states that the repo is published under an MIT license, hence, I thought that I'd change `package.json` to reflect that!